### PR TITLE
Rainstorm

### DIFF
--- a/code/__DEFINES/jadedefines.dm
+++ b/code/__DEFINES/jadedefines.dm
@@ -1,3 +1,4 @@
 //#define JADE_ADMIN_Z_LEVEL 8
 //#define JADE_MAX_MAP_Z_LEVEL 7
 #define JADE_MIN_MAP_Z_LEVEL 1
+#define ZLEVEL_ALL -1

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(weather)
 		return
 	for(var/V in existing_weather)
 		var/datum/weather/W = V
-		if(W.name == weather_name && W.target_z == Z)
+		if(W.name == weather_name && (W.target_z == Z || W.target_z == ZLEVEL_ALL))
 			W.telegraph()
 
 /datum/controller/subsystem/weather/proc/make_z_eligible(zlevel)

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -59,13 +59,13 @@
 		affectareas -= get_areas(V)
 	for(var/V in affectareas)
 		var/area/A = V
-		if(A.z == target_z)
-			impacted_areas |= A
+	//	if(target_z == ZLEVEL_ALL || A.z == target_z)
+		impacted_areas |= A
 	weather_duration = rand(weather_duration_lower, weather_duration_upper)
 	update_areas()
 	for(var/V in GLOB.player_list)
 		var/mob/M = V
-		if(M.z == target_z)
+		if(M.z == target_z || target_z == ZLEVEL_ALL)
 			if(telegraph_message)
 				to_chat(M, telegraph_message)
 			if(telegraph_sound)
@@ -79,7 +79,7 @@
 	update_areas()
 	for(var/V in GLOB.player_list)
 		var/mob/M = V
-		if(M.z == target_z)
+		if(M.z == target_z || target_z == ZLEVEL_ALL)
 			if(weather_message)
 				to_chat(M, weather_message)
 			if(weather_sound)
@@ -110,7 +110,7 @@
 
 /datum/weather/proc/can_impact(mob/living/L) //Can this weather impact a mob?
 	var/turf/mob_turf = get_turf(L)
-	if(mob_turf && (mob_turf.z != target_z))
+	if(mob_turf && (mob_turf.z != target_z && target_z != ZLEVEL_ALL))
 		return
 	if(immunity_type in L.weather_immunities)
 		return

--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -214,3 +214,31 @@
 	var/resist = L.getarmor(null, "acid")
 	if(prob(max(0,100-resist)))
 		L.acid_act(20,20)
+
+
+
+//Rain
+
+/datum/weather/rain
+	name = "rain"
+	desc = "A gentle rain."
+
+	telegraph_duration = 100
+	telegraph_message = "<span class='danger'>A handful of droplets fall from the sky. Looks like rain..</span>"
+	telegraph_sound = 'sound/ambience/acidrain_start.ogg'
+
+	weather_message = "<span class='userdanger'><i>It starts to pour!</i></span>"
+	weather_overlay = "light_rain"
+	weather_duration_lower = 3000
+	weather_duration_upper = 6000
+	weather_sound = 'sound/ambience/acidrain_mid.ogg'
+
+	end_duration = 100
+	end_message = "<span class='notice'>The clouds begin to part. Looks like the rain is letting up.</span>"
+	end_sound = 'sound/ambience/acidrain_end.ogg'
+
+	area_type = /area/outside
+	target_z = ZLEVEL_ALL
+
+/datum/weather/acid_rain/impact(mob/living/L)
+	L.fire_stacks = -20

--- a/code/modules/events/rain.dm
+++ b/code/modules/events/rain.dm
@@ -1,0 +1,9 @@
+/datum/round_event_control/rain
+	name = "Rain"
+	typepath = /datum/round_event/rain
+	max_occurrences = -1
+
+/datum/round_event/rain
+
+/datum/round_event/rain/start()
+	SSweather.run_weather("rain", ZLEVEL_ALL)

--- a/jademansion.dme
+++ b/jademansion.dme
@@ -1235,6 +1235,7 @@
 #include "code\modules\events\prison_break.dm"
 #include "code\modules\events\processor_overload.dm"
 #include "code\modules\events\radiation_storm.dm"
+#include "code\modules\events\rain.dm"
 #include "code\modules\events\sentience.dm"
 #include "code\modules\events\shuttle_loan.dm"
 #include "code\modules\events\spacevine.dm"


### PR DESCRIPTION
I added an override to let weather impact the target area in all z levels.

Right now I left it as an admin only event rather than part of the weather subsystem until you decide what to do with it.

To test it you can use Trigger Event and select Rain.

I'll try to redo weather in /tg/station to play ambiance the entire time and then port that change here